### PR TITLE
perf(`no-unnecessary-polyfills`): use string comparison instead of  regex

### DIFF
--- a/rules/index.js
+++ b/rules/index.js
@@ -188,7 +188,7 @@ const rules = {
 	'no-unnecessary-array-flat-depth': createRule(noUnnecessaryArrayFlatDepth, 'no-unnecessary-array-flat-depth'),
 	'no-unnecessary-array-splice-count': createRule(noUnnecessaryArraySpliceCount, 'no-unnecessary-array-splice-count'),
 	'no-unnecessary-await': createRule(noUnnecessaryAwait, 'no-unnecessary-await'),
-	'no-unnecessary-polyfills': createRule(noUnnecessaryPolyfills, 'no-unnecessary-polyfills'),
+	'no-unnecessary-polyfills': createRule(noUnnecessaryPolyfills, 'no-unnecessary-polyfills', true),
 	'no-unnecessary-slice-end': createRule(noUnnecessarySliceEnd, 'no-unnecessary-slice-end'),
 	'no-unreadable-array-destructuring': createRule(noUnreadableArrayDestructuring, 'no-unreadable-array-destructuring'),
 	'no-unreadable-iife': createRule(noUnreadableIife, 'no-unreadable-iife'),

--- a/rules/no-unnecessary-polyfills.js
+++ b/rules/no-unnecessary-polyfills.js
@@ -39,8 +39,6 @@ const polyfills_ = Object.keys(compatData).map(feature => {
 		additionalName: additionalPolyfillNames[feature],
 	};
 });
-const polyfillWithPrefixOrSuffix =
-	/^(?:(?:mdn-polyfills\/|polyfill-)([\w-]+)|([\w-]+)-polyfill)$/i;
 const modulePrefixSuffix =
 	/(^mdn-polyfills\/|polyfill-)|(-polyfill$)/gi;
 const modulePrefixPattern = /^(?<version>[a-z]+)\d*[./-]/i;
@@ -100,7 +98,6 @@ const findPolyfill = (moduleName) => {
 	const moduleNameLower = moduleName.toLowerCase();
 	const normalisedModuleName =
 		moduleNameLower.replaceAll(modulePrefixSuffix, '');
-	const withPrefixOrSuffix = moduleNameLower.match(polyfillWithPrefixOrSuffix);
 	const modulePrefix = moduleName.match(modulePrefixPattern);
 
 	for (const polyfill of polyfills_) {
@@ -116,15 +113,14 @@ const findPolyfill = (moduleName) => {
 			return polyfill;
 		}
 
-		if (withPrefixOrSuffix) {
+		if (normalisedModuleName !== moduleNameLower) {
 			const methodOrConstructor =
 				methodName || constructorName;
 			const normalisedMethodOrConstructor =
 				normalisedMethodName || normalisedConstructorName;
-			const withPrefixOrSuffixName = withPrefixOrSuffix[1] || withPrefixOrSuffix[2];
 			if (
-				withPrefixOrSuffixName === methodOrConstructor
-				|| withPrefixOrSuffixName === normalisedMethodOrConstructor
+				normalisedModuleName === methodOrConstructor
+				|| normalisedModuleName === normalisedMethodOrConstructor
 			) {
 				return polyfill;
 			}

--- a/rules/utils/rule.js
+++ b/rules/utils/rule.js
@@ -156,7 +156,7 @@ export function checkVueTemplate(create, options) {
 }
 
 /** @returns {import('eslint').Rule.RuleModule} */
-export function createRule(rule, ruleId) {
+export function createRule(rule, ruleId, raw) {
 	return {
 		meta: {
 			// If there is are, options add `[]` so ESLint can validate that no data is passed to the rule.
@@ -168,6 +168,6 @@ export function createRule(rule, ruleId) {
 				url: getDocumentationUrl(ruleId),
 			},
 		},
-		create: reportProblems(rule.create),
+		create: raw ? rule.create : reportProblems(rule.create),
 	};
 }


### PR DESCRIPTION

Currently we build up a huge set of regexes in memory and iterate through them, testing against each one. This is extremely inefficient both for CPU and for memory.

Instead, we can do a few return-early optimisations and string comparisons.

Roughly, this now does the following:

- If the module matches a polyfill's additional name, return it
  - Uses string comparison
- If the module matches the prefix/suffix pattern (e.g. `polyfill-foo`), return it
  - Matches the module name up-front rather than per polyfill
  - String comparison on the matched name if it did match
- If all of this failed, try match delimited parts
  - Matches and strips the prefix up front (e.g. `es6-`)
  - Fails early per-polyfill if the module doesn't begin with the constructor name
  - Returns early per-polyfill if the version was specified and the module is exactly the constructor name (e.g. `es6-promise`)
  - Otherwise, loops through each delimiter and string compares the module
    - Constructing these strings on the fly is better on memory than storing all of them up front when we may never encounter some
    - Also better on CPU since we return early before computing all the other delimiter strings

