### PR TITLE
perf: avoid unnecessary spread

### DIFF
--- a/rules/ast/call-or-new-expression.js
+++ b/rules/ast/call-or-new-expression.js
@@ -8,7 +8,7 @@
 		maximumArguments?: number,
 		allowSpreadElement?: boolean,
 		optional?: boolean,
-	} | string | string[]
+	}
 } CallOrNewExpressionCheckOptions
 */
 function create(node, options, types) {
@@ -16,32 +16,13 @@ function create(node, options, types) {
 		return false;
 	}
 
-	if (typeof options === 'string') {
-		options = {names: [options]};
-	}
-
-	if (Array.isArray(options)) {
-		options = {names: options};
-	}
-
-	let {
-		name,
-		names,
-		argumentsLength,
-		minimumArguments,
-		maximumArguments,
-		allowSpreadElement,
-		optional,
-	} = {
-		minimumArguments: 0,
-		maximumArguments: Number.POSITIVE_INFINITY,
-		allowSpreadElement: false,
-		...options,
-	};
-
-	if (name) {
-		names = [name];
-	}
+	const minimumArguments = options?.minimumArguments ?? 0;
+	const maximumArguments =
+		options?.maximumArguments ?? Number.POSITIVE_INFINITY;
+	const allowSpreadElement = options?.allowSpreadElement ?? false;
+	const names = options?.name ? [options.name] : options?.names;
+	const optional = options?.optional;
+	const argumentsLength = options?.argumentsLength;
 
 	if (
 		(optional === true && node.optional !== optional) ||

--- a/rules/ast/is-member-expression.js
+++ b/rules/ast/is-member-expression.js
@@ -7,7 +7,7 @@
 		objects?: string[],
 		optional?: boolean,
 		computed?: boolean
-	} | string | string[]
+	}
 } [options]
 @returns {string}
 */
@@ -16,28 +16,11 @@ export default function isMemberExpression(node, options) {
 		return false;
 	}
 
-	if (typeof options === 'string') {
-		options = {properties: [options]};
-	}
-
-	if (Array.isArray(options)) {
-		options = {properties: options};
-	}
-
-	let {property, properties, object, objects, optional, computed} = {
-		property: '',
-		properties: [],
-		object: '',
-		...options,
-	};
-
-	if (property) {
-		properties = [property];
-	}
-
-	if (object) {
-		objects = [object];
-	}
+	const property = options?.property ?? '';
+	const properties = property ? [property] : (options?.properties ?? []);
+	const objects = options?.object ? [options.object] : (options?.objects ?? []);
+	const optional = options?.optional;
+	let computed = options?.computed;
 
 	if (
 		(optional === true && node.optional !== optional) ||

--- a/rules/ast/is-method-call.js
+++ b/rules/ast/is-method-call.js
@@ -18,40 +18,26 @@ import {isCallExpression} from './call-or-new-expression.js';
 		objects?: string[],
 		optionalMember?: boolean,
 		computed?: boolean
-	} | string | string[]
+	}
 } [options]
 @returns {string}
 */
 export default function isMethodCall(node, options) {
-	if (typeof options === 'string') {
-		options = {methods: [options]};
-	}
-
-	if (Array.isArray(options)) {
-		options = {methods: options};
-	}
-
-	const {optionalCall, optionalMember, method, methods} = {
-		method: '',
-		methods: [],
-		...options,
-	};
-
 	return (
 		isCallExpression(node, {
 			argumentsLength: options.argumentsLength,
 			minimumArguments: options.minimumArguments,
 			maximumArguments: options.maximumArguments,
 			allowSpreadElement: options.allowSpreadElement,
-			optional: optionalCall,
+			optional: options.optionalCall,
 		}) &&
 		isMemberExpression(node.callee, {
 			object: options.object,
 			objects: options.objects,
 			computed: options.computed,
-			property: method,
-			properties: methods,
-			optional: optionalMember,
+			property: options.method ?? '',
+			properties: options.methods ?? [],
+			optional: options.optionalMember,
 		})
 	);
 }


### PR DESCRIPTION
This seems to have been done because it looks nice, but actually reduces performance since we need to spread `options` for no later reason.