### PR TITLE
perf: always pass same shape to `isMemberExpression`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > More than 100 powerful ESLint rules
 
-A modern and lighter fork of `eslint-plugin-unicorn`.
+A modern, faster and lighter fork of `eslint-plugin-unicorn`.
 
 ## Install
 

--- a/rules/ast/is-member-expression.js
+++ b/rules/ast/is-member-expression.js
@@ -1,10 +1,8 @@
 /**
 @param {
 	{
-		property?: string,
-		properties?: string[],
-		object?: string,
-		objects?: string[],
+		properties?: string[] | string,
+		objects?: string[] | string,
 		optional?: boolean,
 		computed?: boolean
 	}
@@ -16,9 +14,12 @@ export default function isMemberExpression(node, options) {
 		return false;
 	}
 
-	const property = options?.property ?? '';
-	const properties = property ? [property] : (options?.properties ?? []);
-	const objects = options?.object ? [options.object] : (options?.objects ?? []);
+	const properties =
+		typeof options?.properties === 'string'
+			? [options.properties]
+			: options?.properties;
+	const objects =
+		typeof options?.objects === 'string' ? [options.objects] : options?.objects;
 	const optional = options?.optional;
 	let computed = options?.computed;
 

--- a/rules/ast/is-method-call.js
+++ b/rules/ast/is-method-call.js
@@ -32,12 +32,10 @@ export default function isMethodCall(node, options) {
 			optional: options.optionalCall,
 		}) &&
 		isMemberExpression(node.callee, {
-			object: options.object,
-			objects: options.objects,
-			computed: options.computed,
-			property: options.method ?? '',
-			properties: options.methods ?? [],
+			objects: options.object ?? options.objects,
+			properties: options.method ?? options.methods,
 			optional: options.optionalMember,
+			computed: options.computed,
 		})
 	);
 }

--- a/rules/explicit-length-check.js
+++ b/rules/explicit-length-check.js
@@ -156,6 +156,7 @@ function create(context) {
 				!isMemberExpression(memberExpression, {
 					properties: ['length', 'size'],
 					optional: false,
+					computed: undefined,
 				}) ||
 				memberExpression.object.type === 'ThisExpression'
 			) {

--- a/rules/no-anonymous-default-export.js
+++ b/rules/no-anonymous-default-export.js
@@ -186,8 +186,8 @@ const create = (context) => {
 			) ||
 			!(
 				isMemberExpression(node.left, {
-					object: 'module',
-					property: 'exports',
+					objects: 'module',
+					properties: 'exports',
 					computed: false,
 					optional: false,
 				}) || (node.left.type === 'Identifier', node.left.name === 'exports')

--- a/rules/no-useless-length-check.js
+++ b/rules/no-useless-length-check.js
@@ -16,7 +16,11 @@ const isLengthCompareZero = (node) =>
 	node.type === 'BinaryExpression' &&
 	node.right.type === 'Literal' &&
 	node.right.raw === '0' &&
-	isMemberExpression(node.left, {property: 'length', optional: false}) &&
+	isMemberExpression(node.left, {
+		properties: 'length',
+		optional: false,
+		computed: undefined,
+	}) &&
 	isLogicalExpression(node.parent);
 
 function flatLogicalExpression(node) {

--- a/rules/prefer-array-flat.js
+++ b/rules/prefer-array-flat.js
@@ -139,7 +139,7 @@ const arrayPrototypeConcat = {
 					optionalMember: false,
 				}) &&
 				isArrayPrototypeProperty(node.callee.object, {
-					property: 'concat',
+					properties: 'concat',
 				})
 			)
 		) {

--- a/rules/prefer-array-some.js
+++ b/rules/prefer-array-some.js
@@ -167,8 +167,9 @@ const create = (context) => {
 					binaryExpression.right.type === 'Literal' &&
 					binaryExpression.right.raw === '0' &&
 					isMemberExpression(binaryExpression.left, {
-						property: 'length',
+						properties: 'length',
 						optional: false,
+						computed: undefined,
 					}) &&
 					isMethodCall(binaryExpression.left.object, {
 						method: 'filter',

--- a/rules/prefer-dom-node-text-content.js
+++ b/rules/prefer-dom-node-text-content.js
@@ -12,7 +12,9 @@ const create = () => ({
 	MemberExpression(memberExpression) {
 		if (
 			!isMemberExpression(memberExpression, {
-				property: 'innerText',
+				properties: 'innerText',
+				optional: undefined,
+				computed: undefined,
 			})
 		) {
 			return;

--- a/rules/prefer-event-target.js
+++ b/rules/prefer-event-target.js
@@ -70,7 +70,7 @@ function isFromIgnoredPackage(node) {
 	if (
 		isConstVariableDeclarationId(node) &&
 		isMemberExpression(node.parent.init, {
-			property: 'EventEmitter',
+			properties: 'EventEmitter',
 			optional: false,
 			computed: false,
 		}) &&

--- a/rules/prefer-import-meta-properties.js
+++ b/rules/prefer-import-meta-properties.js
@@ -45,7 +45,7 @@ function isNodeBuiltinModuleFunctionCall(
 				!(
 					checkKind === 'property' &&
 					isMemberExpression(node, {
-						property: functionName,
+						properties: functionName,
 						computed: false,
 						optional: false,
 					})

--- a/rules/prefer-prototype-methods.js
+++ b/rules/prefer-prototype-methods.js
@@ -38,7 +38,13 @@ function getConstructorAndMethodName(
 		};
 	}
 
-	if (!isMemberExpression(methodNode, {optional: false})) {
+	if (
+		!isMemberExpression(methodNode, {
+			properties: undefined,
+			optional: false,
+			computed: undefined,
+		})
+	) {
 		return;
 	}
 

--- a/rules/prefer-set-size.js
+++ b/rules/prefer-set-size.js
@@ -66,8 +66,9 @@ const create = (context) => {
 		MemberExpression(node) {
 			if (
 				!isMemberExpression(node, {
-					property: 'length',
+					properties: 'length',
 					optional: false,
+					computed: undefined,
 				}) ||
 				node.object.type !== 'ArrayExpression' ||
 				node.object.elements.length !== 1 ||

--- a/rules/prefer-single-call.js
+++ b/rules/prefer-single-call.js
@@ -24,7 +24,7 @@ const isExpressionStatement = (node) =>
 	node.parent.expression === node;
 const isClassList = (node) =>
 	isMemberExpression(node, {
-		property: 'classList',
+		properties: 'classList',
 		optional: false,
 		computed: false,
 	});

--- a/rules/prefer-top-level-await.js
+++ b/rules/prefer-top-level-await.js
@@ -85,6 +85,7 @@ function create(context) {
 			if (
 				isMemberExpression(node.callee, {
 					properties: promisePrototypeMethods,
+					optional: undefined,
 					computed: false,
 				})
 			) {

--- a/rules/require-array-join-separator.js
+++ b/rules/require-array-join-separator.js
@@ -27,7 +27,7 @@ const create = (context) => ({
 						optionalMember: false,
 					}) &&
 						isArrayPrototypeProperty(node.callee.object, {
-							property: 'join',
+							properties: 'join',
 						}))
 				)
 			)

--- a/rules/shared/no-unnecessary-length-or-infinity-rule.js
+++ b/rules/shared/no-unnecessary-length-or-infinity-rule.js
@@ -11,10 +11,10 @@ function getObjectLengthOrInfinityDescription(node, object) {
 	// `Number.POSITIVE_INFINITY`
 	if (
 		isMemberExpression(node, {
-			object: 'Number',
-			property: 'POSITIVE_INFINITY',
-			computed: false,
+			objects: 'Number',
+			properties: 'POSITIVE_INFINITY',
 			optional: false,
+			computed: false,
 		})
 	) {
 		return 'Number.POSITIVE_INFINITY';
@@ -29,8 +29,11 @@ function getObjectLengthOrInfinityDescription(node, object) {
 	// `object.length`
 	if (
 		!(
-			isMemberExpression(node, {property: 'length', computed: false}) &&
-			isSameReference(object, node.object)
+			isMemberExpression(node, {
+				properties: 'length',
+				optional: undefined,
+				computed: false,
+			}) && isSameReference(object, node.object)
 		)
 	) {
 		return;

--- a/rules/utils/array-or-object-prototype-property.js
+++ b/rules/utils/array-or-object-prototype-property.js
@@ -4,24 +4,20 @@ import {isMemberExpression} from '../ast/index.js';
 @param {
 	{
 		object?: string,
-		method?: string,
-		methods?: string[],
+		properties?: string[] | string,
 	}
 } [options]
 @returns {string}
 */
 function isPrototypeProperty(node, options) {
-	const {object, property, properties} = {
-		property: '',
-		properties: [],
-		...options,
-	};
+	const object = options?.object;
+	const properties = options?.properties ?? [];
 
 	if (
 		!isMemberExpression(node, {
-			property,
 			properties,
 			optional: false,
+			computed: undefined,
 		})
 	) {
 		return;
@@ -32,9 +28,10 @@ function isPrototypeProperty(node, options) {
 	return (
 		// `Object.prototype.method` or `Array.prototype.method`
 		isMemberExpression(objectNode, {
-			object,
-			property: 'prototype',
+			properties: 'prototype',
+			objects: object,
 			optional: false,
+			computed: undefined,
 		}) ||
 		// `[].method`
 		(object === 'Array' &&


### PR DESCRIPTION
A lot of deoptimisation happens because we pass a varied object shape to this. By simplifying it and ensuring all call sites pass the same properties, we get a small performance boost thanks to it no longer having deopted property access.