### PR TITLE
perf(prefer-node-protocol): visit imports/exports

### DIFF
--- a/rules/index.js
+++ b/rules/index.js
@@ -394,6 +394,7 @@ const rules = {
 	'prefer-node-protocol': createRule(
 		preferNodeProtocol,
 		'prefer-node-protocol',
+		true,
 	),
 	'prefer-number-properties': createRule(
 		preferNumberProperties,
@@ -452,6 +453,7 @@ const rules = {
 	'prevent-abbreviations': createRule(
 		preventAbbreviations,
 		'prevent-abbreviations',
+		true,
 	),
 	'relative-url-style': createRule(relativeUrlStyle, 'relative-url-style'),
 	'require-array-join-separator': createRule(


### PR DESCRIPTION
Instead of wastefully visiting every possible `Literal`, we now visit imports/exports directly (of which there are far fewer). This and switching to a raw rule has bumped perf a whole bunch.