### PR TITLE
docs: add link to original repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > More than 100 powerful ESLint rules
 
-A modern, faster and lighter fork of `eslint-plugin-unicorn`.
+A modern, faster and lighter fork of [`eslint-plugin-unicorn`](https://github.com/sindresorhus/eslint-plugin-unicorn).
 
 ## Install
 


### PR DESCRIPTION
To make it easier for users to see known issues in the rules.