### PR TITLE
fix: update docs link

### DIFF
--- a/rules/utils/get-documentation-url.js
+++ b/rules/utils/get-documentation-url.js
@@ -5,5 +5,5 @@ const repoUrl = 'https://github.com/es-tooling/eslint-plugin-unicorn-x';
 
 export default function getDocumentationUrl(filename) {
 	const ruleName = path.basename(filename, '.js');
-	return `${repoUrl}/blob/v${packageJson.version}/docs/rules/${ruleName}.md`;
+	return `${repoUrl}/blob/${packageJson.version}/docs/rules/${ruleName}.md`;
 }

--- a/test/unit/get-documentation-url.js
+++ b/test/unit/get-documentation-url.js
@@ -6,11 +6,11 @@ import packageJson from '../../package.json' with {type: 'json'};
 const filename = url.fileURLToPath(import.meta.url).replace(/\.js$/, '.js');
 
 test("returns the URL of the a named rule's documentation", () => {
-	const url = `https://github.com/es-tooling/eslint-plugin-unicorn-x/blob/v${packageJson.version}/docs/rules/foo.md`;
+	const url = `https://github.com/es-tooling/eslint-plugin-unicorn-x/blob/${packageJson.version}/docs/rules/foo.md`;
 	assert.strictEqual(getDocumentationUrl('foo.js'), url);
 });
 
 test('determines the rule name from the file', () => {
-	const url = `https://github.com/es-tooling/eslint-plugin-unicorn-x/blob/v${packageJson.version}/docs/rules/get-documentation-url.md`;
+	const url = `https://github.com/es-tooling/eslint-plugin-unicorn-x/blob/${packageJson.version}/docs/rules/get-documentation-url.md`;
 	assert.strictEqual(getDocumentationUrl(filename), url);
 });


### PR DESCRIPTION
The documentation link is incorrectly prefixed with `v`.

Fixes #44 